### PR TITLE
feat: gitlab, gitlab runners and web host playbooks

### DIFF
--- a/GCP-README.md
+++ b/GCP-README.md
@@ -1,0 +1,89 @@
+# Selfhosted GitLab-instance and runners setup for Google Cloud Platform
+
+## Prerequisites
+
+- **Debian-based OS on the target machine**.
+- **Hostname pointed to your target machine with GitLab instance**.  
+_This is required for correct runners setup and also for basic email services to work - registration of users, password resets etc_.
+
+
+## Setup
+
+1. Edit the `vars/main.yml`:
+
+   * Assign name of your project to `gcp_project`
+   * Generate **Service Account auth file**:  
+     - Go to the hamburger menu in the top left corner to open the main navigation menu
+     - Navigate to **IAM & Admin** -> **Service Accounts**
+     - Click on default Service Account in the list
+     - On Service Account page select **Keys**
+     - Click on **ADD KEY** -> **Create new key**
+     - Select **JSON** and click **CREATE*
+     - The browser will download auth file automatically
+     - Rename file to `service.json` and move it to `secure/service.json`
+   * Assign service account email to `service_account_email`
+     * It's available in service account auth file under `client_email`
+   * Assign hostname associated with your GitLab instance IP to `gitlab_hostname`.
+   * Assign existing root password (or the one you want to create GitLab instance with) to `gitlab_root_password`
+   * Assign ghcr.io link to GitHub account to `gitlab_runner_allowed_images`
+     * Example `ghcr.io/jetbrains-academy/python-cub/*`  
+
+
+2. _(optional)_ Reserver IP addresses for GitLab instance and/or GitLab runners server:
+   * Go to the hamburger menu in the top left corner to open the main navigation menu
+   * Navigate to **VPC network** -> **IP addresses**
+   * Click on **RESERVE EXTERNAL STATIC IP ADDRESS**
+   * Give it appropriate name and description
+   * Select **Network Service Tier** - **Standard**
+   * Select **IP version** - **IPv4**
+   * Select **Type** - **Regional** and set **Region** to the region you'll use for your servers
+     * By default, this config uses region `europe-west1` (Belgium) when creating instance
+   * Assign reserved IPs to `gitlab_server_ip` and `gitlab_runner_server_ip` in `vars/main.yml` and uncomment them
+
+## Installation
+
+### Full rollout
+
+Full roll-out includes:
+1) Creating VM for GitLab instance
+2) Creating VM for GilLab runners
+3) Installing GitLab, including mail server and SSL certificate for the hostname
+4) Installing GitLab shared runner on VM, registering it with GitLab instance
+
+Run the playbook
+```shell
+ansible-playbook -i inventory.ini playbooks/gitlab.yml --skip-tags "logging"
+```
+
+Remove `--skip-logging "logging"` to download GitLab installation log, GitLab config file and printing GitLab runner token during execution.
+
+### Only instantiating VMs
+
+This option will only instantiate either one or both VMs, without installing GitLab or Runner.  
+You can than install GitLab and runner via dedicated playbooks described in [main readme file](README.md)
+
+Run the playbook
+```shell
+ansible-playbook -i inventory.ini playbooks/gitlab.yml --tags "gitlab-server-vm" --skip-tags "logging"
+```
+or
+```shell
+ansible-playbook -i inventory.ini playbooks/gitlab.yml --tags "gitlab-runners-vm" --skip-tags "logging"
+```
+
+The default values like number of CPU, RAM, disk size etc. are available in [this file](roles/create_gcp_instance/defaults/main.yml).  
+They also can be edited in the [playbook](playbooks/GCP_for_gitlab.yml).
+Default zone for the VM is Europe, Belgium (`europe-west1-b`)
+
+### Instantiate VM and install GitLab/runners separately
+
+This option will instantiate VM and install GitLab or runners separately.
+
+Run the playbook
+```shell
+ansible-playbook -i inventory.ini playbooks/gitlab.yml --tags "gitlab-install" --skip-tags "logging"
+```
+or
+```shell
+ansible-playbook -i inventory.ini playbooks/gitlab.yml --tags "gitlab-runners-install" --skip-tags "logging"
+```

--- a/README.md
+++ b/README.md
@@ -7,13 +7,15 @@ This repository contains Ansible playbooks to setup a Manytask infrastructure.
 All, one or several of the following services can be installed:
 * **GitLab server** - setup self-hosted GitLab instance \w docker registry, etc.
 * **Web server**    - setup server to host the Manytask web application in a docker.
-* **GitLab Runner** - setup self-hosted GitLab CI runner(s) to run CI/CD jobs from gitlab.com or self-hosted GitLab server (for students' jobs).
+* **GitLab Runner** - setup self-hosted GitLab CI runner(s) to run CI/CD jobs from self-hosted GitLab server (for students' jobs).
 * **GitHub Runner** - setup self-hosted GitHub Actions runner(s) to run CI/CD jobs from github.com (for private repos).
 
 Note: GitLab and GitHub runners can be installed on the same server. 
 
 
 ## Prerequisites
+
+- Debian-based OS on target machine (for GitLab instance and its runners).
 - Ansible installed on your control machine.
   ```shell
   # Optional: Create a virtual environment
@@ -36,8 +38,8 @@ Note: GitLab and GitHub runners can be installed on the same server.
 2. Edit the `vars/main.yml` file to match your infrastructure.
   * For github runner, you need to provide a github-runner registration token. You can find it in your github repository settings.
     Repo -> Settings -> Actions -> Runners -> New self-hosted runner -> Copy the registration token.
-  * For gitlab runner, you need to provide a gitlab-runner registration token. You can find it in your gitlab group settings.
-    Group/Repo -> Build -> Runners -> New [group] runner -> Create Runner -> Copy the registration token.
+  * For GitLab runner, you need to provide password for root account.
+  * You need hostname associated with your GitLab instance IP.
 3. Run the playbooks you want:
   ```shell
   ansible-playbook -i inventory.ini playbooks/gitlab.yml
@@ -45,6 +47,7 @@ Note: GitLab and GitHub runners can be installed on the same server.
   ansible-playbook -i inventory.ini playbooks/github_runner.yml
   ansible-playbook -i inventory.ini playbooks/gitlab_runner.yml
   ```
+5. If you want to use Google Cloud Platform for installation, you need to follow instruction in [GCP guide](GCP-README.md).
 
 
 ## Development

--- a/playbooks/GCP_for_gitlab.yml
+++ b/playbooks/GCP_for_gitlab.yml
@@ -1,0 +1,92 @@
+---
+# ==================================================
+- name: Create GCP VM for Gitlab
+  hosts: localhost
+
+  vars_files:
+    - ../vars/main.yml
+  tags:
+    - "gitlab-server-vm"
+    - "gitlab-install"
+
+  roles:
+    - role: create_gcp_instance
+      instance_name: "server"
+      instance_address: "{{ gitlab_server_ip | default(omit) }}"
+      machine_ram: 16384
+
+  tasks:
+    - name: "Record runner server's IP"
+      add_host:
+        name: "{{ global_nat_ip }}"
+        groups: "gitlab_ip"
+
+
+# ==================================================
+- name: Create GCP VM for Gitlab's runners
+  hosts: localhost
+
+  vars_files:
+    - ../vars/main.yml
+  tags:
+    - "gitlab-runners-vm"
+    - "gitlab-runners-install"
+
+  roles:
+    - role: create_gcp_instance
+      instance_name: "runners"
+      instance_address: "{{ gitlab_runner_server_ip | default(omit) }}"
+      machine_ram: 8192
+
+  tasks:
+    - name: "Record runner server's IP"
+      add_host:
+        name: "{{ global_nat_ip }}"
+        groups: "runners_ip"
+
+# ==================================================
+- name: Configure GitLab Server host
+  hosts: gitlab_ip
+
+  vars_files:
+    - ../vars/main.yml
+
+  tags:
+    - "gitlab-install"
+
+  roles:
+    - role: packages_install
+      packages_install_list: "{{ default_packages_to_install }}"
+      become: true
+    - role: hifis.unattended_upgrades
+      unattended_automatic_reboot_time: 04:00  # noqa: var-naming[no-role-prefix]
+      become: true
+    - role: geerlingguy.security
+      security_ssh_port: "22"
+      become: true
+    - role: gitlab_server_install
+
+# ==================================================
+- name: Configure GitLab runners Server host
+  hosts: runners_ip
+#  hosts: gitlab_runner
+
+  vars_files:
+    - ../vars/main.yml
+
+  tags:
+    - "gitlab-runners-install"
+
+  roles:
+    - role: packages_install
+      packages_install_list: "{{ default_packages_to_install }}"
+      become: true
+    - role: hifis.unattended_upgrades
+      unattended_automatic_reboot_time: 04:00  # noqa: var-naming[no-role-prefix]
+      become: true
+    - role: geerlingguy.security
+      security_ssh_port: "22"
+      become: true
+    - role: geerlingguy.docker
+      become: true
+    - role: runners_install

--- a/playbooks/gitlab.yml
+++ b/playbooks/gitlab.yml
@@ -17,5 +17,4 @@
     - role: geerlingguy.security
       security_ssh_port: "22"
       become: true
-    - role: debops.gitlab
-      # TODO: configure gitlab https://github.com/debops/debops-playbooks/blob/master/playbooks/common.yml
+    - role: gitlab_server_install

--- a/playbooks/gitlab_runner.yml
+++ b/playbooks/gitlab_runner.yml
@@ -6,16 +6,6 @@
   vars_files:
     - ../vars/main.yml
 
-
-  pre_tasks:
-    - name: HOTFIX - allow gitlab-runner role to make "dpkg_selections"
-      ansible.builtin.shell: |
-        curl -L "https://packages.gitlab.com/install/repositories/runner/gitlab-runner/script.deb.sh" | sudo bash
-        sudo dpkg --configure -a
-      become: true
-      changed_when: false
-
-
   roles:
     - role: packages_install
       packages_install_list: "{{ default_packages_to_install }}"
@@ -28,7 +18,7 @@
       become: true
     - role: geerlingguy.docker
       become: true
-    - role: riemers.ansible-gitlab-runner
+    - role: runners_install
 
 
   tasks:

--- a/playbooks/web.yml
+++ b/playbooks/web.yml
@@ -32,5 +32,5 @@
         user: root
       become: true
 
-  - name: Setup web servers
+    - name: Setup web servers
     # TODO: add web servers

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 yamllint
 ansible
 ansible-lint
+google-auth

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,4 +3,3 @@ roles:
   - geerlingguy.security
   - geerlingguy.docker
   - macunha1.github_actions_runner
-  - riemers.ansible-gitlab-runner

--- a/roles/create_gcp_instance/defaults/main.yml
+++ b/roles/create_gcp_instance/defaults/main.yml
@@ -1,0 +1,12 @@
+gcp_cred_kind: serviceaccount
+gcp_cred_file: "../secure/service.json"
+gcp_zone: europe-west1-b
+machine_spec: n2
+machine_cpu: 4
+machine_ram: 8192
+source_image: "projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts"
+disk_type: "pd-balanced"
+disk_size: 160
+vm_tags: { items: ["http-server", "https-server"] }
+scopes:
+  - "https://www.googleapis.com/auth/compute"

--- a/roles/create_gcp_instance/tasks/main.yml
+++ b/roles/create_gcp_instance/tasks/main.yml
@@ -1,0 +1,63 @@
+---
+
+- name: Create a GCP instance
+  google.cloud.gcp_compute_instance:
+    state: present
+    project: "{{ gcp_project | mandatory }}"
+    auth_kind: "{{ gcp_cred_kind }}"
+    service_account_file: "{{ gcp_cred_file }}"
+    zone: "{{ gcp_zone }}"
+    name: "{{ instance_name | mandatory }}"
+    machine_type: "{{ machine_spec }}-custom-{{ machine_cpu }}-{{ machine_ram }}"
+    disks:
+      - auto_delete: true
+        boot: true
+        initialize_params:
+          source_image: "{{ source_image }}"
+          disk_type: "{{ disk_type }}"
+          disk_size_gb: "{{ disk_size }}"
+    network_interfaces:
+      - access_configs:
+          - name: External NAT
+            network_tier: "STANDARD"
+            nat_ip: "{{ instance_address | default(omit) }}"
+            type: ONE_TO_ONE_NAT
+    tags: "{{ vm_tags }}"
+    shielded_instance_config:
+      enable_secure_boot: false
+      enable_vtpm: true
+      enable_integrity_monitoring: true
+    scheduling:
+      preemptible: false
+      automatic_restart: true
+      on_host_maintenance: "MIGRATE"
+    service_accounts:
+      - email: "{{ service_account_email | mandatory }}"
+        scopes: "{{ scopes }}"
+  register: gcp_vm_server
+
+- name: Set global_nat_ip for access in other roles or playbooks
+  set_fact:
+    global_nat_ip: "{{ gcp_vm_server.networkInterfaces[0].accessConfigs[0].natIP }}"
+
+  when: gcp_vm_server.networkInterfaces is defined and 
+        gcp_vm_server.networkInterfaces | length > 0 and
+        gcp_vm_server.networkInterfaces[0].accessConfigs is defined and
+        gcp_vm_server.networkInterfaces[0].accessConfigs | length > 0
+
+- name: Current IP for {{ instance_name }}
+  debug:
+    msg: "{{ global_nat_ip }}"
+
+- name: Wait for SSH to be available
+  wait_for:
+    host: "{{ global_nat_ip }}"
+    port: 22
+    delay: 10
+    timeout: 300
+
+- name: Add SSH key to known hosts
+  known_hosts:
+    name: "{{ global_nat_ip }}"
+    key: "{{ lookup('pipe', 'ssh-keyscan -t rsa ' + global_nat_ip) }}"
+    state: present

--- a/roles/gitlab_server_install/handlers/main.yml
+++ b/roles/gitlab_server_install/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: Restart Postfix
+  service:
+    name: postfix
+    state: restarted

--- a/roles/gitlab_server_install/tasks/gitlab_setup.yml
+++ b/roles/gitlab_server_install/tasks/gitlab_setup.yml
@@ -1,0 +1,68 @@
+---
+- name: Add GitLab repository
+  ansible.builtin.shell: |
+    curl -sS https://packages.gitlab.com/install/repositories/gitlab/gitlab-ce/script.deb.sh | sudo bash
+  args:
+    executable: /bin/bash
+  environment:
+    DEBIAN_FRONTEND: noninteractive
+
+- name: Install GitLab CE
+  ansible.builtin.shell: |
+    apt update
+    apt install gitlab-ce -y |& tee /tmp/gitlab_install.log
+  args:
+    executable: /bin/bash
+  environment:
+    EXTERNAL_URL: "{{ (gitlab_hostname is defined) | ternary('https://', 'http://') }}{{ gitlab_hostname | default(inventory_hostname) }}"
+    DEBIAN_FRONTEND: noninteractive
+  register: gitlab_install
+
+- name: Fetch GitLab install log
+  ansible.builtin.fetch:
+    src: /tmp/gitlab_install.log
+    dest: "{{ playbook_dir }}/gitlab_install_logs/"
+    flat: yes
+  tags:
+    - logging
+
+- name: Copy GitLab configuration file to temporary location
+  ansible.builtin.command:
+    cmd: cp /etc/gitlab/gitlab.rb /tmp/temp_gitlab.rb
+  register: copy_gitlab_config
+  tags:
+    - logging
+
+- name: Change permissions of temporary GitLab configuration file
+  ansible.builtin.file:
+    path: /tmp/temp_gitlab.rb
+    mode: '0644'
+  when: copy_gitlab_config is changed
+  tags:
+    - logging
+
+- name: Fetch GitLab configuration file from temporary location
+  ansible.builtin.fetch:
+    src: /tmp/temp_gitlab.rb
+    dest: "{{ playbook_dir }}/gitlab_config_files/"
+    flat: yes
+  tags:
+    - logging
+
+- name: Set new root password
+  ansible.builtin.shell: |
+    sudo gitlab-rails runner "user = User.where(id{{ ':' }} 1).first; user.password = '{{ gitlab_root_password }}'; user.password_confirmation = '{{ gitlab_root_password }}'; user.save!"
+  args:
+    executable: /bin/bash
+  environment:
+    DEBIAN_FRONTEND: noninteractive
+
+- name: Restart GitLab
+  ansible.builtin.command:
+    cmd: gitlab-ctl restart
+  environment:
+    DEBIAN_FRONTEND: noninteractive
+
+- name: Wait for GitLab to restart
+  pause:
+    minutes: 2

--- a/roles/gitlab_server_install/tasks/main.yml
+++ b/roles/gitlab_server_install/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Install and Configure Postfix for GitLab Server
+  become: yes
+  become_method: sudo
+  import_tasks: postfix_setup.yml
+
+- name: Install GitLab on gitlab-server
+  become: yes
+  become_method: sudo
+  import_tasks: gitlab_setup.yml

--- a/roles/gitlab_server_install/tasks/postfix_setup.yml
+++ b/roles/gitlab_server_install/tasks/postfix_setup.yml
@@ -1,0 +1,20 @@
+---
+- name: Update package cache
+  apt:
+    update_cache: yes
+  changed_when: false
+
+- name: Install Postfix
+  apt:
+    name: postfix
+    state: present
+
+- name: Set Postfix main mailer type
+  debconf:
+    name: postfix
+    question: "postfix/main_mailer_type"
+    value: "Internet Site"
+    vtype: "string"
+  with_items:
+    - "{{ gitlab_hostname | default(inventory_hostname) }}"
+  notify: Restart Postfix

--- a/roles/runners_install/tasks/main.yml
+++ b/roles/runners_install/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+- name: "Create runner on Gilab instance"
+  delegate_to: localhost
+  import_tasks: runner_create.yml
+
+- name: Install runner on the host and configure it
+  become: yes
+  become_method: sudo
+  import_tasks: runner_install.yml
+

--- a/roles/runners_install/tasks/runner_create.yml
+++ b/roles/runners_install/tasks/runner_create.yml
@@ -1,0 +1,32 @@
+---
+
+- name: "Get oauth token from https://{{ gitlab_hostname }}/oauth/token"
+  uri:
+    url: "https://{{ gitlab_hostname }}/oauth/token?grant_type=password&username=root&password={{ gitlab_root_password }}"
+    method: POST
+    return_content: yes
+    status_code: 200
+    body_format: json
+    validate_certs: yes
+  register: token
+
+- name: Create runner on GitLab instance
+  uri:
+    url: "https://{{ gitlab_hostname }}/api/v4/user/runners"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ token.json.access_token }}"
+    body_format: json
+    body:
+      runner_type: "instance_type"
+      description: "Default runner for this instance."
+      run_untagged: true
+    status_code: [ 201 ] # 201 is created, 409 is already exists; makes idempotent
+    validate_certs: yes
+  register: runner_token
+
+- name: Runner Token Print
+  debug:
+    msg: "{{ runner_token.json.token }}"
+  tags:
+    - logging

--- a/roles/runners_install/tasks/runner_install.yml
+++ b/roles/runners_install/tasks/runner_install.yml
@@ -1,0 +1,32 @@
+---
+
+- name: Add Gitlab runner repository
+  ansible.builtin.shell: |
+    curl -sS https://packages.gitlab.com/install/repositories/runner/gitlab-runner/script.deb.sh | sudo bash
+  args:
+    executable: /bin/bash
+  environment:
+    DEBIAN_FRONTEND: noninteractive
+
+- name: Install GitLab Runner
+  ansible.builtin.apt:
+    name: gitlab-runner
+    update_cache: yes
+    state: present
+
+- name: Create Runner config template
+  template:
+    src: gitlab-runner-config.toml.j2
+    dest: /tmp/runner-config.toml
+
+- name: Register GitLab Runner
+  ansible.builtin.shell: >
+    gitlab-runner register --non-interactive
+    --url "https://{{ gitlab_hostname }}/"
+    --token "{{ runner_token.json.token }}"
+    --executor "docker"
+    --docker-image "docker:latest"
+    --description "docker-runner"
+    --request-concurrency {{ gitlab_runner_concurrent_specific }}
+  environment:
+    TEMPLATE_CONFIG_FILE: /tmp/runner-config.toml

--- a/roles/runners_install/templates/gitlab-runner-config.toml.j2
+++ b/roles/runners_install/templates/gitlab-runner-config.toml.j2
@@ -1,0 +1,14 @@
+[[runners]]
+  [runners.docker]
+    tls_verify = false
+    memory = "{{ gitlab_runner_docker_memory }}"
+    cpus = "{{ gitlab_runner_docker_cpu }}"
+    cap_add = ["SYS_ADMIN"]
+    privileged = {{ gitlab_runner_docker_privileged | lower }}
+    disable_entrypoint_overwrite = false
+    oom_kill_disable = false
+    disable_cache = false
+    volumes = [{% for volume in gitlab_runner_docker_volumes %}"{{ volume }}"{% if not loop.last %}, {% endif %}{% endfor %}]
+    allowed_images = [{% for image in gitlab_runner_allowed_images %}"{{ image }}"{% if not loop.last %}, {% endif %}{% endfor %}]
+    pull_policy = ["always"]
+    shm_size = 0

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -12,30 +12,26 @@ default_packages_to_install:
   - gzip
   - nano
 
+gcp_project: "YOUR_GCP_PROJECT_NAME"
+service_account_email: "YOUR_SERVICE_ACCOUNT_EMAIL"
+
+#Password must not contain commonly used combinations of words and letters
+gitlab_root_password: "ROOT_PASSWORD_YOU_WANT"
+gitlab_hostname: "GITLAB_HOSTNAME"
+
+#gitlab_server_ip: { address: "YOUR_GITLAB_SERVER_IP" }
+#gitlab_runner_server_ip: { address: "YOUR_GITLAB_RUNNER_SERVER_IP" }
 
 github_runner_config_url: https://github.com/manytask/course-template
 github_runner_config_token: 'TODO-TODO-TODO-TODO-TODO-TODO-TODO-TODO-TODO-TODO-TODO-TODO'
 github_runner_config_labels: ["self-hosted"]
 
 
-gitlab_runner_coordinator_url: https://gitlab.com
-gitlab_runner_registration_token: 'TODO-TODO-TODO-TODO-TODO-TODO-TODO-TODO-TODO-TODO-TODO-TODO'
-gitlab_runner_runners:
-  - name: 'Example Docker GitLab Runner'
-    executor: docker
-    docker_privileged: false  # TODO: check if privileged is needed
-    docker_image: 'alpine'
-    tags: ['shared']
-    docker_volumes:
-      - "/var/run/docker.sock:/var/run/docker.sock"
-      - "/cache"
-    concurrent_specific: 2
-    extra_registration_option: '--maximum-timeout=1800'  # in seconds
-    extra_configs:
-      runners.docker:
-        memory: "1g"
-        cpus: "2"
-        oom_kill_disable: false
-        shm_size: 0
-        pull_policy: "always"
-        allowed_images: ["registry.gitlab.com/manytask/test/course-template-test-public/*:*"]
+gitlab_runner_docker_privileged: true  # TODO: check if privileged is needed
+gitlab_runner_docker_memory: "3g"
+gitlab_runner_docker_cpu: "2"
+gitlab_runner_docker_image: 'docker:latest'
+gitlab_runner_docker_volumes: ["/var/run/docker.sock:/var/run/docker.sock", "/cache"]
+gitlab_runner_allowed_images: ["YOUR_GHCR_IO_FORMATED_REPO_WITH_DOCKER_IMAGES"]
+gitlab_runner_pull_policy: "always"
+gitlab_runner_concurrent_specific: 2


### PR DESCRIPTION
I've added new roles for installing gitlab and latest version of runners with new authorization flow.
Playbooks will work on next version of gitlab server/runners automatically - they get latest version of the server/runners.
Documentation for automatic rollout on GCP is added in additional document.

Currently CI for checking of playbooks and for GitHub runners is not ready, but should be less work and will add this week.